### PR TITLE
Integrate Danger PR checks into ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
 
 jobs:
-  test:
+  ci:
     name: CI
     runs-on: macos-latest
 
@@ -20,14 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-
-      - name: Danger
-        if: github.event_name == 'pull_request'
-        run: |
-          brew install danger/tap/danger-swift
-          danger-swift ci --failOnErrors
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore cached dependencies
         id: cocoapods-cache
@@ -45,3 +37,18 @@ jobs:
 
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "FlickrSearch.xcworkspace" -scheme "FlickrSearch" -destination "${{ matrix.destination }}" -enableCodeCoverage YES clean test | xcpretty
+
+  danger:
+    name: Danger
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Danger
+        uses: danger/swift@3.0.0
+        with:
+            args: --failOnErrors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Danger
+        if: github.event_name == 'pull_request'
+        run: |
+          brew install danger/tap/danger-swift
+          danger-swift ci --failOnErrors
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Restore cached dependencies
         id: cocoapods-cache
         uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
   danger:
     name: Danger
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: Checkout

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,29 @@
+import Danger
+import Foundation
+
+let danger = Danger()
+
+let modifiedFiles = danger.git.modifiedFiles + danger.git.createdFiles
+let modifiedSwiftFiles = modifiedFiles.filter { $0.hasSuffix(".swift") }
+
+// Check if PR is still in progress
+if danger.github.pullRequest.title.contains("WIP") {
+    warn("PR is classed as Work in Progress")
+}
+
+// Check if no code was updated without tests
+let testsUpdated = danger.git.modifiedFiles.contains { $0.hasSuffix("Tests.swift") }
+if !modifiedSwiftFiles.isEmpty && !testsUpdated {
+    warn("Swift files were changed, but the tests remained unmodified. Consider updating or adding to the tests to match the code changes.")
+}
+
+// Check PR title
+let prTitle = danger.github.pullRequest.title
+if let firstCharacter = prTitle.first, firstCharacter.isLowercase {
+    warn("PR title should start with an uppercase letter.")
+}
+
+let prTitleMaxLength = 65
+if prTitle.count > prTitleMaxLength {
+    fail("PR title is too long. It should be less then \(prTitleMaxLength).")
+}


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also, consider providing considered alternatives to current implementation. -->
Danger is a pretty powerful tool to check your PRs, starting from PR titles and finishing with code. Decided to integrate it to add additional checks.

### What has been done?
1. Integrate Danger PR checks into ci workflow

### How to test?
1. Check that Danger runs on this PR. Also, you can test the rules that are described there, but the cheks will not be triggered unless something is pushed 🤷‍♂️
