### PR TITLE
Run swiftlint only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
   swiftlint:
     name: Swiftlint
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
Running `swiftlint` on every push does no give much value since the changes may land into `master` branch only through pull request. If any necessity will arrive, this may be reverted/adjusted.

### What has been done?
1. Run swiftlint only on pull requests

### How to test?
1. Check that `swiftlint` job wasn't launched twice (on push and pr event), and should be run only on pull request trigger.
