### PR TITLE
Add ci and codecov status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # FlickrSearch
+![CI](https://github.com/lexorus/flickr-search/workflows/CI/badge.svg) [![codecov](https://codecov.io/gh/lexorus/flickr-search/branch/master/graph/badge.svg)](https://codecov.io/gh/lexorus/flickr-search)
 
 `FlickrSearch` is a single view application that can search trough Flickr photos using [Flickr API](https://www.flickr.com/services/api) and then displays the search results in a paginated collection view.
 The application was written using Xcode 11.2.1 and Swift 5.1


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
We should always keep an eye on CI and coverage statuses. That's why I'm adding those to `README.md`

### What has been done?
1. Add `CI` status badge from GitHub Actions
2. Add `codecov` status badge from codecov.io

### How to test?
1. The status badges should be visible in `README.md`
