### PR TITLE
Implement Rx adapter for PhotosAPI

### DIFF
--- a/FlickrSearch.xcodeproj/project.pbxproj
+++ b/FlickrSearch.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		B11DDF0B243C73BB00C52E32 /* MockPhotosPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11DDF0A243C73BB00C52E32 /* MockPhotosPage.swift */; };
 		B11DDF11243C766700C52E32 /* MockPhotosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11DDF10243C766700C52E32 /* MockPhotosAPI.swift */; };
 		B11DDF13243C78AD00C52E32 /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11DDF12243C78AD00C52E32 /* DataExtensions.swift */; };
+		B13243862451A63E006E4BBE /* RxPhotosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13243852451A63E006E4BBE /* RxPhotosAPI.swift */; };
+		B13243882451B180006E4BBE /* PhotosAPIRxAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13243872451B180006E4BBE /* PhotosAPIRxAdapterTests.swift */; };
 		B1429BD324334088001478D4 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1429BD224334088001478D4 /* SearchViewModel.swift */; };
 		B174F9452434B25C00A9A4A8 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B174F9442434B25C00A9A4A8 /* StringExtensions.swift */; };
 		B19BB4CF243CC91100ACC7D0 /* FlickrPhotosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B19BB4CE243CC91100ACC7D0 /* FlickrPhotosAPI.swift */; };
@@ -195,6 +197,8 @@
 		B11DDF0A243C73BB00C52E32 /* MockPhotosPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPhotosPage.swift; sourceTree = "<group>"; };
 		B11DDF10243C766700C52E32 /* MockPhotosAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPhotosAPI.swift; sourceTree = "<group>"; };
 		B11DDF12243C78AD00C52E32 /* DataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
+		B13243852451A63E006E4BBE /* RxPhotosAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxPhotosAPI.swift; sourceTree = "<group>"; };
+		B13243872451B180006E4BBE /* PhotosAPIRxAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosAPIRxAdapterTests.swift; sourceTree = "<group>"; };
 		B1429BD224334088001478D4 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		B174F9442434B25C00A9A4A8 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		B19BB4CE243CC91100ACC7D0 /* FlickrPhotosAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlickrPhotosAPI.swift; sourceTree = "<group>"; };
@@ -407,6 +411,7 @@
 		653EC70023813E53007F1404 /* FlickrAPI */ = {
 			isa = PBXGroup;
 			children = (
+				B13243852451A63E006E4BBE /* RxPhotosAPI.swift */,
 				65C932F323820D3500460C36 /* FetcherFacade.swift */,
 				653EC723238161F6007F1404 /* Services */,
 			);
@@ -418,6 +423,7 @@
 			children = (
 				651C017423855B11003BE167 /* FetcherFacadeTests.swift */,
 				651C017623855B45003BE167 /* Mocks */,
+				B13243872451B180006E4BBE /* PhotosAPIRxAdapterTests.swift */,
 			);
 			path = FlickrAPI;
 			sourceTree = "<group>";
@@ -1117,6 +1123,7 @@
 				652A0265238328E1005F1181 /* PhotoCell.swift in Sources */,
 				650401F223836B0900B78A73 /* LoadingFooter.swift in Sources */,
 				B1FD2D572435E64E00871D76 /* UICollectionViewLayoutBuilder.swift in Sources */,
+				B13243862451A63E006E4BBE /* RxPhotosAPI.swift in Sources */,
 				65E07DBA23834F8300384B72 /* IdentifiableType.swift in Sources */,
 				B1429BD324334088001478D4 /* SearchViewModel.swift in Sources */,
 				651C017323854DC3003BE167 /* Atomic.swift in Sources */,
@@ -1134,6 +1141,7 @@
 				65CC6FFC2384895E00406610 /* PaginatorTests.swift in Sources */,
 				65CC6FFF2384926700406610 /* MockFetcher.swift in Sources */,
 				651C017823855B79003BE167 /* MockImageCacher.swift in Sources */,
+				B13243882451B180006E4BBE /* PhotosAPIRxAdapterTests.swift in Sources */,
 				B1E26C5C243601DD00EA9664 /* SearchViewModelTests.swift in Sources */,
 				65CC700B2384A45F00406610 /* MockSearchedPhotosFetcher.swift in Sources */,
 				651C017523855B11003BE167 /* FetcherFacadeTests.swift in Sources */,

--- a/FlickrSearch/FlickrAPI/FetcherFacade.swift
+++ b/FlickrSearch/FlickrAPI/FetcherFacade.swift
@@ -37,7 +37,7 @@ final class Fetcher: FetcherType {
                 callback(.success(data))
                 return
             }
-            self?.flickrFetcher.getImageData(for: photo) { [weak self] result in
+            _ = self?.flickrFetcher.getImageData(for: photo) { [weak self] result in
                 callback(result)
                 guard let data = try? result.get() else { return }
                 self?.imageCacher.set(imageData: data, for: photo.id)

--- a/FlickrSearch/FlickrAPI/RxPhotosAPI.swift
+++ b/FlickrSearch/FlickrAPI/RxPhotosAPI.swift
@@ -1,0 +1,50 @@
+import PhotosAPI
+import RxSwift
+
+protocol RxPhotosAPI {
+    func getPhotos(query: String, pageNumber: UInt, pageSize: UInt) -> Single<PhotosPage>
+    func getImageData(for photo: Photo) -> Single<Data>
+}
+
+final class PhotosAPIRxAdapter: RxPhotosAPI {
+    private let api: PhotosAPI
+
+    init(photosAPI: PhotosAPI) {
+        api = photosAPI
+    }
+
+    func getPhotos(query: String, pageNumber: UInt, pageSize: UInt) -> Single<PhotosPage> {
+        return Single.create { observer in
+            let callback: (Result<PhotosPage, APIError>) -> Void = { result in
+                switch result {
+                case .success(let response):
+                    observer(.success(response))
+                case .failure(let error):
+                    observer(.error(error))
+                }
+            }
+            let cancellable = self.api.getPhotos(query: query,
+                                                 pageNumber: pageNumber,
+                                                 pageSize: pageSize,
+                                                 callback: callback)
+
+            return Disposables.create { cancellable.cancel() }
+        }
+    }
+
+    func getImageData(for photo: Photo) -> Single<Data> {
+        return Single.create { observer in
+            let callback: (Result<Data, APIError>) -> Void = { result in
+                switch result {
+                case .success(let response):
+                    observer(.success(response))
+                case .failure(let error):
+                    observer(.error(error))
+                }
+            }
+            let cancellable = self.api.getImageData(for: photo, callback: callback)
+
+            return Disposables.create { cancellable.cancel() }
+        }
+    }
+}

--- a/FlickrSearchTests/FlickrAPI/PhotosAPIRxAdapterTests.swift
+++ b/FlickrSearchTests/FlickrAPI/PhotosAPIRxAdapterTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import RxSwift
+import PhotosAPI
+import PhotosAPIMocks
+import RxBlocking
+@testable import FlickrSearch
+
+final class PhotosAPIRxAdapterTests: XCTestCase {
+    var disposeBag: DisposeBag!
+    var mockAPI: MockPhotosAPI!
+    var rxAPI: PhotosAPIRxAdapter!
+
+    override func setUp() {
+        super.setUp()
+
+        disposeBag = DisposeBag()
+        mockAPI = MockPhotosAPI()
+        rxAPI = PhotosAPIRxAdapter(photosAPI: mockAPI)
+    }
+
+    override func tearDown() {
+        rxAPI = nil
+        mockAPI = nil
+        disposeBag = nil
+
+        super.tearDown()
+    }
+
+    // MARK: - getPhotos
+    func test_whenGetPhotosAPIWillFail_thenSingleErrorEventShouldBeEmitted() {
+        // GIVEN
+        var response: PhotosPage?
+        var error: Error?
+        rxAPI.getPhotos(query: "query", pageNumber: 0, pageSize: 0)
+            .subscribe(onSuccess: { response = $0 },
+                       onError: { error = $0 })
+            .disposed(by: disposeBag)
+
+        // WHEN
+        let apiError = APIError.noDataError
+        mockAPI.getPhotosFuncCheck.arguments?.3(.failure(apiError))
+
+        // THEN
+        XCTAssertNil(response)
+        XCTAssertEqual(error as? APIError, apiError)
+    }
+
+    func test_whenGetPhotosAPIFechesPhotosSuccesfully_thenSingleSuccessEventShouldBeEmitted() {
+        // GIVEN
+        var response: PhotosPage?
+        var error: Error?
+        rxAPI.getPhotos(query: "query", pageNumber: 0, pageSize: 0)
+            .subscribe(onSuccess: { response = $0 },
+                       onError: { error = $0 })
+            .disposed(by: disposeBag)
+
+        // WHEN
+        let apiResult = PhotosPage.mocked()
+        mockAPI.getPhotosFuncCheck.arguments?.3(.success(apiResult))
+
+        // THEN
+        XCTAssertNil(error)
+        XCTAssertEqual(response, apiResult)
+    }
+
+    func test_whenGetPhotosAPICallbackIsCalledMultipleTimes_thenOnlyOneEventShouldBeEmitted() {
+        // GIVEN
+        var response: PhotosPage?
+        var error: Error?
+        rxAPI.getPhotos(query: "query", pageNumber: 0, pageSize: 0)
+            .subscribe(onSuccess: { response = $0 },
+                       onError: { error = $0 })
+            .disposed(by: disposeBag)
+
+        // WHEN
+        let firstAPIResponse = PhotosPage.mocked()
+        mockAPI.getPhotosFuncCheck.arguments?.3(.success(firstAPIResponse))
+        let secondAPIResponse = PhotosPage.mocked(pageNumber: 2)
+        mockAPI.getPhotosFuncCheck.arguments?.3(.success(secondAPIResponse))
+
+        // THEN
+        XCTAssertNil(error)
+        XCTAssertEqual(response, firstAPIResponse)
+    }
+
+    // MARK: - getImageData
+    func test_whengetImageDataWillFail_thenSingleErrorEventShouldBeEmitted() {
+        // GIVEN
+        var response: Data?
+        var error: Error?
+        rxAPI.getImageData(for: .mocked())
+            .subscribe(onSuccess: { response = $0 },
+                       onError: { error = $0 })
+            .disposed(by: disposeBag)
+
+        // WHEN
+        let apiError = APIError.noDataError
+        mockAPI.getImageDataFuncCheck.arguments?.1(.failure(apiError))
+
+        // THEN
+        XCTAssertNil(response)
+        XCTAssertEqual(error as? APIError, apiError)
+    }
+
+    func test_whengetImageDataFechesPhotosSuccesfully_thenSingleSuccessEventShouldBeEmitted() {
+        // GIVEN
+        var response: Data?
+        var error: Error?
+        rxAPI.getImageData(for: .mocked())
+            .subscribe(onSuccess: { response = $0 },
+                       onError: { error = $0 })
+            .disposed(by: disposeBag)
+
+        // WHEN
+        let apiResult = Data()
+        mockAPI.getImageDataFuncCheck.arguments?.1(.success(apiResult))
+
+        // THEN
+        XCTAssertNil(error)
+        XCTAssertEqual(response, apiResult)
+    }
+}

--- a/PhotosAPI/Sources/FlickrPhotosAPI.swift
+++ b/PhotosAPI/Sources/FlickrPhotosAPI.swift
@@ -33,7 +33,7 @@ public final class FlickrPhotosAPI: PhotosAPI {
         }
     }
 
-    public func getImageData(for photo: Photo, callback: @escaping (Result<Data, APIError>) -> Void) {
+    public func getImageData(for photo: Photo, callback: @escaping (Result<Data, APIError>) -> Void) -> Cancellable {
         let urlString = PhotoStringURLBuilder().urlString(for: photo)
         return getData(from: urlString, callback: callback)
     }
@@ -58,12 +58,12 @@ public final class FlickrPhotosAPI: PhotosAPI {
         }
     }
 
-    private func getData(from stringURL: String, callback: @escaping (Result<Data, APIError>) -> Void) {
+    private func getData(from stringURL: String, callback: @escaping (Result<Data, APIError>) -> Void) -> Cancellable {
         guard let url = URL(string: stringURL) else {
             callback(.failure(.failedToBuildURLRequest))
-            return
+            return EmptyCancellable()
         }
-        perform(URLRequest(url: url), callback: callback)
+        return perform(URLRequest(url: url), callback: callback)
     }
 
     @discardableResult

--- a/PhotosAPI/Sources/PhotosAPI.swift
+++ b/PhotosAPI/Sources/PhotosAPI.swift
@@ -7,5 +7,5 @@ public protocol PhotosAPI {
                    callback: @escaping (Result<PhotosPage, APIError>) -> Void) -> Cancellable
 
     func getImageData(for photo: Photo,
-                      callback: @escaping (Result<Data, APIError>) -> Void)
+                      callback: @escaping (Result<Data, APIError>) -> Void) -> Cancellable
 }

--- a/PhotosAPIMocks/Sources/Mocks/MockPhotosAPI.swift
+++ b/PhotosAPIMocks/Sources/Mocks/MockPhotosAPI.swift
@@ -5,6 +5,7 @@ public final class MockPhotosAPI: PhotosAPI {
 
     public var getPhotosStub = MockCancellable()
     public var getPhotosFuncCheck = FuncCheck<(String, UInt, UInt, (Result<PhotosPage, APIError>) -> Void)>()
+    @discardableResult
     public func getPhotos(query: String, pageNumber: UInt, pageSize: UInt,
                           callback: @escaping (Result<PhotosPage, APIError>) -> Void) -> Cancellable {
         getPhotosFuncCheck.call((query, pageNumber, pageSize, callback))
@@ -12,8 +13,13 @@ public final class MockPhotosAPI: PhotosAPI {
         return getPhotosStub
     }
 
+    public var getImageDataStub = MockCancellable()
     public var getImageDataFuncCheck = FuncCheck<(Photo, (Result<Data, APIError>) -> Void)>()
-    public func getImageData(for photo: Photo, callback: @escaping (Result<Data, APIError>) -> Void) {
+    @discardableResult
+    public func getImageData(for photo: Photo,
+                             callback: @escaping (Result<Data, APIError>) -> Void) -> Cancellable {
         getImageDataFuncCheck.call((photo, callback))
+
+        return getImageDataStub
     }
 }

--- a/PhotosAPITests/Sources/FlickrPhotosAPITests.swift
+++ b/PhotosAPITests/Sources/FlickrPhotosAPITests.swift
@@ -73,7 +73,7 @@ final class FlickrPhotosAPITests: XCTestCase {
 
         // WHEN
         var resultToTest: Result<Data, APIError>?
-        fetcher.getImageData(for: .mocked(id: "??%%")) {
+        _ = fetcher.getImageData(for: .mocked(id: "??%%")) {
             resultToTest = $0
         }
 
@@ -88,7 +88,7 @@ final class FlickrPhotosAPITests: XCTestCase {
 
         // WHEN
         var resultToTest: Result<Data, APIError>?
-        fetcher.getImageData(for: .mocked()) {
+        _ = fetcher.getImageData(for: .mocked()) {
             resultToTest = $0
         }
         mockNetwork.dataTaskCompletion?(.success(sampleData))


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
Since we moved to `MVVM`(aka reactive approach), it will be great to make all of our business logic more reactive. I decided to leave `PhotosAPI` apart, with to `RxSwift` integration. However, the application will use `PhotosAPIRxAdapter`.

### What has been done?
1. Implement `PhotosAPIRxAdapter`
2. Add tests for it
3. Make `getImageData` request of `PhotosAPI` - `Cancellable`

### How to test?
Since the adapter is not yet connected to the `ViewModel`, there is no way to test this from the user perspective. Basically, the tests and `CI` should pass.
