### PR TITLE
Move Danger and Swiftlint into separate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Restore cached dependencies
         id: cocoapods-cache
@@ -43,35 +43,3 @@ jobs:
         with:
           name: flickr-search
           fail_ci_if_error: true
-
-
-  danger:
-    name: Danger
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Danger
-        uses: danger/swift@3.0.0
-        with:
-            args: --failOnErrors --no-publish-check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
-  swiftlint:
-    name: Swiftlint
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Swiftlint
-        uses: norio-nomura/action-swiftlint@3.1.0
-        env:
-          DIFF_BASE: ${{ github.base_ref }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,22 @@
+name: Danger
+
+# Documentation with macOS virtual environment:
+# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+
+on: [pull_request]
+
+jobs:
+  danger:
+    name: Danger
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Danger
+        uses: danger/swift@3.0.0
+        with:
+            args: --failOnErrors --no-publish-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,20 @@
+name: Swiftlint
+
+# Documentation with macOS virtual environment:
+# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+
+on: [pull_request]
+
+jobs:
+  swiftlint:
+    name: Swiftlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Swiftlint
+        uses: norio-nomura/action-swiftlint@3.1.0
+        env:
+          DIFF_BASE: ${{ github.base_ref }}


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
At the moment all automated checks are part of `CI` workflow, event if they are separate jobs. 
The main reason for these changes to happen:
1. If checks in `CI` workflow: 
`if: github.event_name == 'pull_request'`
2. Skipped checks in the report:
<img width="500" alt="Screen Shot 2020-04-23 at 18 18 23" src="https://user-images.githubusercontent.com/10234295/80116693-f1fd9700-858e-11ea-98d6-0d78d4852748.png">


### What has been done?
1. Move Danger and Swiftlint into separate workflows

### How to test?
Check the statuses. `Test and codecov` jobs should run on both `pr and push` events. `danger` and `swiftlint` jobs should run only on `pr` event.
