### PR TITLE
Force fetch PR base branch for Swiftlint workflow

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Force fetch base branch
+        run: git fetch --no-tags --prune --depth=1 origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
       - name: Swiftlint
         uses: norio-nomura/action-swiftlint@3.1.0
         env:


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
In PR https://github.com/lexorus/flickr-search/pull/12, besides moving `Danger` and `Swiftlint` into separate workflows, the `actions/checkout@v2` was used instead of `actions/checkout@v1`.
As it turns out, `v2` is optimized to fetch much less than `v1`. As a result, `swiftlint` workflow wasn't able to report since if failed to identify changed files.
Look here for more details:
https://github.com/lexorus/flickr-search/runs/620276617?check_suite_focus=true
https://github.com/lexorus/flickr-search/pull/13

### What has been done?
1. Force fetch PR base branch for Swiftlint workflow

### How to test?
This was actully tested in the mentioned PR (https://github.com/lexorus/flickr-search/pull/12) where the misbehavior was noticed.
The testing results can be seed in this workflow runs:
https://github.com/lexorus/flickr-search/runs/620276617?check_suite_focus=true
https://github.com/lexorus/flickr-search/runs/626951662?check_suite_focus=true
https://github.com/lexorus/flickr-search/actions/runs/90400464?check_suite_focus=true
https://github.com/lexorus/flickr-search/runs/627057826?check_suite_focus=true