### PR TITLE
Integrate changes labeler github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+"changed:app":
+  - FlickrSearch/**/*
+  - FlickrSearchTests/**/*
+
+"changed:api":
+  - PhotosAPI/**/*
+  - PhotosAPIMocks/**/*
+  - PhotosAPITests/**/*
+
+"changed:ci":
+  - .swiftlint.yml
+  - Dangerfile.swift
+  - codecov.yml
+  - .github/**/*
+
+"changed:dependencies":
+  - Podfile
+  - Podfile.lock

--- a/.github/workflows/changes_labeler.yml
+++ b/.github/workflows/changes_labeler.yml
@@ -1,0 +1,17 @@
+name: Changes labeler
+
+# Documentation with macOS virtual environment:
+# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+
+on: [pull_request]
+
+jobs:
+  triage:
+    name: Changes labeler
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label PR based on changes
+        uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
Will be great if we could automate the generation of PR changes sum-up based on the files that were changed. This will allow us to easily understand which parts of the app/repo were affected. Sometimes this is helpful to prioritize PR in a team to avoid complex conflicts, to spot the changes that shouldn't be really part of the opened PR, or to understand which parts of the applications should be user-tested.
One of the solutions is to use https://github.com/actions/labeler, to automatically set PR labels based on the files that were changed. Let's see how it works 👀


### What has been done?
1. Integrate new github actions workflow described in `changes_labeler.yml`
2. Specify labeling rules in `labeler.yml`

### How to test?
Make changes in different parts of the repository and make sure that the right labels were assigned to PR.
