### PR TITLE
Fix typo in Dangerfile.swift

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -26,5 +26,5 @@ if let firstCharacter = prTitle.first, firstCharacter.isLowercase {
 
 let prTitleMaxLength = 65
 if prTitle.count > prTitleMaxLength {
-    fail("PR title is too long. It should be less then \(prTitleMaxLength).")
+    fail("PR title is too long. It should be less than \(prTitleMaxLength).")
 }


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
Just fixing a small typo.

### What has been done?
1. `PR title is too long. It should be less then` -> `PR title is too long. It should be less than`

### How to test?
Just read carefully 🙃
