### PR TITLE
Integrate automerge GitHub Action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,7 +17,7 @@ on:
   check_suite:
     types:
       - completed
-  status:
+  status: {}
 
 jobs:
   automerge:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,39 @@
+name: PR automerge
+
+# Automatic deletion of PR branches after merge is done through GitHub repository settings
+# https://docs.github.com/en/github/administering-a-repository/managing-the-automatic-deletion-of-branches
+
+# "Require branches to be up to date before merging" is also enabled for the repository
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status:
+
+jobs:
+  automerge:
+    name: Automerge
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge,!do NOT merge,!invalid,wontfix"
+          MERGE_METHOD: "squash"
+          MERGE_COMMIT_MESSAGE: "automatic"
+          MERGE_FORKS: "false"
+          MERGE_RETRIES: "2"
+          MERGE_RETRY_SLEEP: "60000"
+          MERGE_DELETE_BRANCH: "true"
+          UPDATE_METHOD: "rebase"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,7 +29,7 @@ jobs:
         uses: pascalgn/automerge-action@v0.8.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "automerge,!do NOT merge,!invalid,wontfix"
+          MERGE_LABELS: "automerge,!do NOT merge,!invalid,!wontfix"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "automatic"
           MERGE_FORKS: "false"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,6 +17,9 @@ on:
   check_suite:
     types:
       - completed
+  check_run:
+    types:
+      - completed
   status: {}
 
 jobs:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action"
+        uses: pascalgn/automerge-action@v0.8.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "automerge,!do NOT merge,!invalid,wontfix"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,6 +11,8 @@ on:
       - labeled
       - unlabeled
       - synchronize
+      - edited
+      - unlocked
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/changes_labeler.yml
+++ b/.github/workflows/changes_labeler.yml
@@ -1,8 +1,5 @@
 name: Changes labeler
 
-# Documentation with macOS virtual environment:
-# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
-
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "FlickrSearch.xcworkspace" -scheme "FlickrSearch" -destination "${{ matrix.destination }}" -enableCodeCoverage YES clean test | xcpretty
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.0.10
         with:
           name: flickr-search
           fail_ci_if_error: true

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,8 +1,5 @@
 name: Danger
 
-# Documentation with macOS virtual environment:
-# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
-
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,8 +1,5 @@
 name: Swiftlint
 
-# Documentation with macOS virtual environment:
-# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
-
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
Sometimes the review is already done and the PR is approved, but you cannot merge a PR because the CI didn't pass yet,
either because it is enforced by the repository setting (which is a good thing), or you just want to be sure that the CI passes before merging.
There is a [GitHub Action](https://github.com/pascalgn/automerge-action) that can automate this process. It will be launched on a set of events (like adding a label or change of the PR status), and will automerge your PR is CI passed. Let's see it in action.

### What has been done?
1. Integrate [automerge](https://github.com/pascalgn/automerge-action) GitHub Action
2. Remove comments about macOS evn setup from actions that run on ubuntu

### How to test?
The PR should be automerged 😁
