### PR TITLE
Update automerge action workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -12,21 +12,21 @@ name: PR automerge
 # To bypass this the codecov status reporting is used. It will be reported at the end of `ci` workflow and trigger
 # automerge workflow.
 
-on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-  pull_request_review:
-    types:
-      - submitted
-  check_suite:
-    types:
-      - completed
-  check_run:
-    types:
-      - completed
-  status: {}
+on: [pull_request]
+  # pull_request:
+  #   types:
+  #     - labeled
+  #     - unlabeled
+  # pull_request_review:
+  #   types:
+  #     - submitted
+  # check_suite:
+  #   types:
+  #     - completed
+  # check_run:
+  #   types:
+  #     - completed
+  # status: {}
 
 jobs:
   automerge:
@@ -34,7 +34,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Wait for CI
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-build
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: CI
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: automerge
+        if: steps.wait-for-build.outputs.conclusion == 'success'
         uses: pascalgn/automerge-action@v0.8.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -12,7 +12,7 @@ name: PR automerge
 # To bypass this the codecov status reporting is used. It will be reported at the end of `ci` workflow and trigger
 # automerge workflow.
 
-on: [pull_request]
+on:
   # pull_request:
   #   types:
   #     - labeled
@@ -26,7 +26,7 @@ on: [pull_request]
   # check_run:
   #   types:
   #     - completed
-  # status: {}
+  status: {}
 
 jobs:
   automerge:
@@ -34,16 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Wait for CI
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-build
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: CI
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
       - name: automerge
-        if: steps.wait-for-build.outputs.conclusion == 'success'
         uses: pascalgn/automerge-action@v0.8.4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,19 +13,13 @@ name: PR automerge
 # automerge workflow.
 
 on:
-  # pull_request:
-  #   types:
-  #     - labeled
-  #     - unlabeled
-  # pull_request_review:
-  #   types:
-  #     - submitted
-  # check_suite:
-  #   types:
-  #     - completed
-  # check_run:
-  #   types:
-  #     - completed
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
   status: {}
 
 jobs:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,8 +9,10 @@ name: PR automerge
 #
 # "check_suite" and "check_run" are not triggered for the GitHub Actions to prevent recusivity. More information
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#check_suite
-# To bypass this the codecov status reporting is used. It will be reported at the end of `ci` workflow and trigger
-# automerge workflow.
+# Also, it is impossible to trigger other workflows using the GitHub Actions default token for the same reasons.
+#
+# That's why, this workflow is triggered by the status that is posted on success from "CI" workflow.
+#
 
 on:
   pull_request:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,18 +1,22 @@
 name: PR automerge
 
+# Important notes:
+#
 # Automatic deletion of PR branches after merge is done through GitHub repository settings
 # https://docs.github.com/en/github/administering-a-repository/managing-the-automatic-deletion-of-branches
-
+#
 # "Require branches to be up to date before merging" is also enabled for the repository
+#
+# "check_suite" and "check_run" are not triggered for the GitHub Actions to prevent recusivity. More information
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#check_suite
+# To bypass this the codecov status reporting is used. It will be reported at the end of `ci` workflow and trigger
+# automerge workflow.
 
 on:
   pull_request:
     types:
       - labeled
       - unlabeled
-      - synchronize
-      - edited
-      - unlocked
   pull_request_review:
     types:
       - submitted
@@ -38,7 +42,7 @@ jobs:
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "automatic"
           MERGE_FORKS: "false"
-          MERGE_RETRIES: "0"
-          MERGE_RETRY_SLEEP: "60000"
+          MERGE_RETRIES: "0" # Preventing retry mechanism
+          MERGE_RETRY_SLEEP: "0"
           MERGE_DELETE_BRANCH: "true"
           UPDATE_METHOD: "rebase"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -38,7 +38,7 @@ jobs:
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "automatic"
           MERGE_FORKS: "false"
-          MERGE_RETRIES: "2"
+          MERGE_RETRIES: "0"
           MERGE_RETRY_SLEEP: "60000"
           MERGE_DELETE_BRANCH: "true"
           UPDATE_METHOD: "rebase"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,13 @@ jobs:
           name: flickr-search
           fail_ci_if_error: true
 
+      # This is neccessary to trigger "automerge" workflow
       - name: Update commit status
         if: ${{ github.event_name == 'pull_request' && success() }}
         uses: ouzi-dev/commit-status-updater@v1.0.4
         with:
+          # You cannot trigger another workflow using default GitHub actions token to prevent recursive jobs, that's why custom token is used.
+          # More info: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
           token: ${{ secrets.COMMIT_STATUS_TOKEN }}
           status: "success"
           name: "CI - Ok to automerge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,4 @@ jobs:
         with:
           token: ${{ secrets.COMMIT_STATUS_TOKEN }}
           status: "success"
+          name: "CI - Ok to automerge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,10 @@ jobs:
         with:
           name: flickr-search
           fail_ci_if_error: true
+
+      - name: Update commit status
+        if: ${{ github.event_name == 'pull_request' && success() }}
+        uses: ouzi-dev/commit-status-updater@v1.0.4
+        with:
+          token: ${{ secrets.COMMIT_STATUS_TOKEN }}
+          status: "success"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: true
+  require_ci_to_pass: false
 
 coverage:
   range: 0..100

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
 
 coverage:
   range: 0..100


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
Automerge GitHub Action was integrated into this project https://github.com/lexorus/flickr-search/pull/20. Some of the triggers specified for it did not work either because the workflow definition was not yet merged into master, or because some statuses are not reported to prevent recursive workflows, like `check_suite` and `check_run`. For more info visit [documentation](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#check_suite).

After the `automerge workflow` was merged in `master`(default branch), the status triggers start working.
Another think is that you cannot trigger another workflow using default GitHub actions token to prevent recursive jobs, that's why only the codecov status reports are triggering `automerge`.

Since I didn't want to leave the `automerge` action rely on `retry mechanism`, which checks the specified number of times each specified amout of time if the PR is available for merge, I integrated the commit status posting as part of the `CI` workflow run, using the [commit-status-updater](https://github.com/marketplace/actions/commit-status-updater) GitHub actions.

### Considered alternatives
1. There is an github action "[Wait For Check](https://github.com/marketplace/actions/wait-for-check)". I tried it but it basically is doing the same thing, checking every 10 seconds if the given workflow is not finished yet. You can see it [here](https://github.com/lexorus/flickr-search/pull/21/checks?check_run_id=863305867).

### What has been done?
1. Disabled `retry` mechanism of the `automerge` workflow
2. Cleaned up the `automerge` triggers so the workflow will be triggered on `status reporting`, `labeled/unlabeled` and `review submission`
3. Added some important notes on top of `auromerge` workflow definition file and in `CI` workflow 

### How to test?
1. Automerge should not merge PR if it has `do NOT merge` label on it.
2. `CI` workflow should pass, and the one triggered for `pull_request` should post the `success` state, which should trigger the `automerge` workflow
