### PR TITLE
Add --force-exclude option to swiftlint action

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,5 +16,7 @@ jobs:
 
       - name: Swiftlint
         uses: norio-nomura/action-swiftlint@3.1.0
+        with:
+           args: --force-exclude
         env:
           DIFF_BASE: ${{ github.base_ref }}


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
[swiftlint github action](https://github.com/norio-nomura/action-swiftlint) that is used here in this project runs only on modified files ignoring the `.swiftlint.yml` config file, please see this issue: https://github.com/norio-nomura/action-swiftlint/issues/23
This is surely unexpected behavior and there is a way to fix it using `--force-exclude` flag.

### What has been done?
1. Add `--force-exclude` to swiftlint github action

### How to test?
This was tested and modified as part of this PR: https://github.com/lexorus/flickr-search/pull/22, but I decided to have it a separate commit on `master`. To actually test this you need to:
1. Open PR
2. Modify `swift` files that are excluded in `swiftlint.yml`
3. Check that they weren't linted during swiftlint github action
