### PR TITLE
Fix automerge workflow not triggering CI after merge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -33,7 +33,7 @@ jobs:
       - name: automerge
         uses: pascalgn/automerge-action@v0.8.4
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.AUTOMERGE_TOKEN }}"
           MERGE_LABELS: "automerge,!do NOT merge,!invalid,!wontfix"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "automatic"


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
I noticed that CI is not triggered on `master` branch after a merge is done using `automerge` workflow. This is because `automerge` workflow is using defaut `GITHUB_TOKEN` which is not allowed to trigger other GitHub actions.

### What has been done?
1. Specified a new token for automerge workflow using `GitHub` secrets

### How to test?
1. Check that CI passed after PR was merged using `automerge`
