### PR TITLE
Remove completed items from README.md's TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,5 @@ To run the application on device you will need to specify the "Development Team"
 * Add a debouncer that will prevent the requests before used finishes typing.
 * Adjust ImageCaching with a possibility to save on disc.
 * Improve collection layout based on image sizes/orientations.
-* Move API logic in a separate target.
-* Configure CI with Swiftlint and Danger.
 * Add nice application icon and launch screen.
 * Cover the View part of SearchModule with tests.


### PR DESCRIPTION
### Background
<!-- Why these changes are necessary? Also consider providing considered alternatives to current implementation. -->
I notices that some things from `README` `TODO`s were already done:
* Move API logic in a separate target.
* Configure CI with Swiftlint and Danger.

### What has been done?
1. Remove completed items from `README.md`s `TODOs`

### How to test?
Nothing to test really. You can check that those points were really implemented 😅
